### PR TITLE
proxy to petfinder api

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Find an adoptable cat that suits your needs
 2. Install frontend dependencies
     `$ npm install`
 
-3. Create environment variable for your `SECRET_KEY`
+3. Create environment variables for your `SECRET_KEY` and `PETFINDER_API_KEY`
 
 4. Initial frontend build
     `$ npm run build`

--- a/backend/catcall/settings.py
+++ b/backend/catcall/settings.py
@@ -30,6 +30,7 @@ def get_env_variable(var_name):
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = get_env_variable('SECRET_KEY')
+PETFINDER_API_KEY = get_env_variable('PETFINDER_API_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -58,6 +59,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'webpack_loader',
+    'proxy',
 ]
 
 MIDDLEWARE = [

--- a/backend/catcall/urls.py
+++ b/backend/catcall/urls.py
@@ -16,8 +16,10 @@ Including another URLconf
 from django.conf.urls import url
 from django.contrib import admin
 from django.views.generic import TemplateView
+from .views import petfinder_view
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='index.html')),
     url(r'^admin/', admin.site.urls),
-]
+    url(r'^api/(?P<path>.*)$', petfinder_view)]
+

--- a/backend/catcall/views.py
+++ b/backend/catcall/views.py
@@ -1,0 +1,9 @@
+from settings import PETFINDER_API_KEY
+from proxy.views import proxy_view
+
+def petfinder_view(request, path):
+    requests_args = {'params': {'key': PETFINDER_API_KEY, 'format':'json', 'animal': 'cat'}}
+    remoteurl = 'http://api.petfinder.com/' + path
+    return proxy_view(request, remoteurl, requests_args)
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
+certifi==2018.1.18
+chardet==3.0.4
 Django==1.11
+django-proxy==1.1.0
 django-webpack-loader==0.5.0
+idna==2.6
 psycopg2==2.7.3.2
 pytz==2017.3
+requests==2.18.4
+urllib3==1.22


### PR DESCRIPTION
As the code is right now, default arguments that remain the same across calls like the api key, format, and animal type are sent with the request.  
Petfinder api method and path including method specific required arguments will be provided by the call from frontend
ex:
api/pet.get?id=31555333
api/pet.getRandom?&output=full
api/breed.list?
api/pet.find?&location=11221