### PR TITLE
cat list api call and reducer

### DIFF
--- a/frontend/app/actions/catListActions.js
+++ b/frontend/app/actions/catListActions.js
@@ -1,0 +1,24 @@
+import { RSAA } from 'redux-api-middleware'
+
+export const REQUEST = 'CAT_LIST_REQUEST'
+export const SUCCESS = 'CAT_LIST_SUCCESS'
+export const FAILURE = 'CAT_LIST_FAILURE'
+
+export function fetchCatList(location) {
+  return {
+    [RSAA]: {
+      endpoint: '/api/pet.find?&location=' + location,
+      method: 'GET',
+      types: [
+        REQUEST,
+        {
+          type: SUCCESS,
+          payload: (action, state, res) => {
+            return res.json().then(json => json['petfinder']['pets'])
+          }
+        },
+        FAILURE
+      ]
+    }
+  }
+}

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -10,6 +10,7 @@ import App from './app'
 import { fetchRandomCat } from './actions/catActions'
 import { fetchBreeds } from './actions/breedActions'
 import { fetchCatDetail } from './actions/catDetailActions'
+import { fetchCatList } from './actions/catListActions'
 import rootReducer from './reducers/index'
 
 const store = createStore(
@@ -19,11 +20,6 @@ const store = createStore(
     thunkMiddleware
   )
 )
-
-store.dispatch(fetchCatDetail(31555507))
-//store.dispatch(fetchBreeds())
-//store.dispatch(fetchRandomCat())
-  .then(() => console.log(store.getState()))
 
 render(
     <Provider store={store}>

--- a/frontend/app/reducers/catListReducer.js
+++ b/frontend/app/reducers/catListReducer.js
@@ -1,0 +1,29 @@
+import { REQUEST, SUCCESS, FAILURE } from '../actions/catListActions'
+
+const initialState= {
+  isFetching: false,
+  catList: []
+}
+
+function catList(state = initialState, action) {
+  switch (action.type) {
+    case REQUEST:
+      return Object.assign({}, state, {
+        isFetching: true
+    })
+    case FAILURE:
+      return Object.assign({}, state, {
+        isFetching: false,
+        error: action.payload
+    })
+    case SUCCESS:
+      return Object.assign({}, state, {
+        isFetching: false,
+        catList: action.payload
+    })
+    default:
+      return state
+  }
+}
+
+export default catList;

--- a/frontend/app/reducers/index.js
+++ b/frontend/app/reducers/index.js
@@ -2,9 +2,11 @@ import { combineReducers } from 'redux'
 import randomCat from './catReducer'
 import breedReducer from './breedReducer'
 import catDetail from './catDetailReducer'
+import catList from './catListReducer'
 
 export default combineReducers({
   randomCat: randomCat,
   breeds: breedReducer,
   catDetail: catDetail
+  catList: catList
 })


### PR DESCRIPTION
Just the boilerplate action and reducer for the `pet.find?` call that returns a list of cats. There is a sample dispatched call with a zipcode being logged to the console. When this will actually be dispatched in the app it will get its parameters from the search form when the user clicks the submit button. I'm assuming it will be possible to pass in an object with named parameters to construct the full url endpoint. 