### PR TITLE
removes icons from form validation, adds help text

### DIFF
--- a/frontend/app/components/locationForm.jsx
+++ b/frontend/app/components/locationForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FormControl, FormGroup, ControlLabel, Button } from 'react-bootstrap'
+import { FormControl, FormGroup, HelpBlock, Button } from 'react-bootstrap'
 
 class LocationForm extends React.Component {
   constructor(props) {
@@ -21,7 +21,9 @@ class LocationForm extends React.Component {
                placeholder="Enter your Zip Code"
                onChange={onChange}
             />
-            <FormControl.Feedback />
+           {validation == 'error' ?
+            <HelpBlock>Please enter a valid zip code</HelpBlock>
+           : null }
           </FormGroup>
           <Button type="submit">Find A Cat</Button>
         </form>


### PR DESCRIPTION
resolves #68 
Remove `Formcontrol.Feedback` component to not use validation icons. 
Add help text while form validation state is in error state. 