### PR TITLE
access petfinder api

### DIFF
--- a/backend/catcall/settings/base.py
+++ b/backend/catcall/settings/base.py
@@ -30,6 +30,7 @@ def get_env_variable(var_name):
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = get_env_variable('SECRET_KEY')
 PETFINDER_API_KEY = get_env_variable('PETFINDER_API_KEY')
+PETFINDER_SECRET = get_env_variable('PETFINDER_SECRET')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/backend/catcall/views.py
+++ b/backend/catcall/views.py
@@ -1,9 +1,23 @@
-from catcall.settings.base import PETFINDER_API_KEY
+from catcall.settings.base import PETFINDER_API_KEY, PETFINDER_SECRET
 from proxy.views import proxy_view
+import requests
+
+def authenticate():
+    url = 'http://api.petfinder.com/v2/oauth2/token'
+    data = {
+        'grant_type': 'client_credentials',
+        'client_id': PETFINDER_API_KEY,
+        'client_secret': PETFINDER_SECRET
+    }
+
+    r = requests.post(url, data=data)
+    return r.json()['access_token']
 
 def petfinder_view(request, path):
-    requests_args = {'params': {'key': PETFINDER_API_KEY, 'format':'json', 'animal': 'cat', 'count': 30 }}
-    remoteurl = 'http://api.petfinder.com/' + path
+    requests_args = { 'headers': {'Authorization': 'Bearer ' + authenticate()},
+                      'params': { 'type': 'cat', 'limit': 30 }
+                     }
+    remoteurl = 'http://api.petfinder.com/v2/' + path
     return proxy_view(request, remoteurl, requests_args)
 
 


### PR DESCRIPTION
- creates a helper function `authenticate` that sends a request with api key and secret and returns the access token. 

- `authenticate` function is called to add the token to the headers args in the proxy view to get a successful response from the new petfinder api 