### PR TITLE
add distance parameter to list endpoint call in list action

### DIFF
--- a/frontend/app/actions/catListActions.js
+++ b/frontend/app/actions/catListActions.js
@@ -8,7 +8,7 @@ export const CLEAR = 'CAT_LIST_CLEAR'
 export function fetchCatList(location, page) {
   return {
     [RSAA]: {
-      endpoint: '/api/animals?&location=' + location + '&page=' +  page,
+      endpoint: '/api/animals?&location=' + location + '&distance=10' + '&page=' + page,
       method: 'GET',
       types: [
         REQUEST,


### PR DESCRIPTION
Changes distance parameter to 10 miles to the list endpoint call. Results are sorted by how recent pets are added so this was needed to prevent showing cats that are actually 100 miles away in the early cat list results. 