### PR TITLE
detail loading view on mobile

### DIFF
--- a/frontend/app/components/catList.jsx
+++ b/frontend/app/components/catList.jsx
@@ -16,6 +16,7 @@ class CatList extends React.Component {
   }
 
   handleInfiniteLoad() {
+    this.setState({isInfiniteLoading: true})
     setTimeout(() => {
       this.setState({ page : this.state.page + 1,
                       isInfiniteLoading: false}),

--- a/frontend/app/containers/detailContainer.jsx
+++ b/frontend/app/containers/detailContainer.jsx
@@ -33,7 +33,9 @@ class DetailContainer extends React.Component {
     }
     else if ( isFetching || Object.entries(catDetail).length === 0  ) {
       return(
-        <Loading />
+        <div className="view">
+          <Loading />
+        </div>
       )
     }
     return (


### PR DESCRIPTION
resolves #120 

1. adds back `isInfiniteLoading` state change in `handleInfiniteLoad` function so that loading screen will appear on initial list view/component render 

2. adds div with view class on detail view loading screen to match same format as in list view. (loading component is no longer cut off because there is enough padding for nav) 