### PR TITLE
set word wrap property on contact details to prevent overflow on mobile

### DIFF
--- a/frontend/app/styles/main.css
+++ b/frontend/app/styles/main.css
@@ -196,6 +196,7 @@ h3 {
     justify-content: flex-start;
     height: 75%;
     color: var(--ebony);
+    word-wrap: break-word;
 }
 
 .data-pill {


### PR DESCRIPTION
resolves #122 